### PR TITLE
certmgrd: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/org.webosports.service.certmgr.api.json
+++ b/files/sysbus/org.webosports.service.certmgr.api.json
@@ -1,15 +1,5 @@
 {
-    "applications": [
-        "org.webosports.service.certmgr/listAll",
-        "org.webosports.service.certmgr/install",
-        "org.webosports.service.certmgr/remove"
-    ],
-    "services": [
-        "org.webosports.service.certmgr/listAll",
-        "org.webosports.service.certmgr/install",
-        "org.webosports.service.certmgr/remove"
-    ],
-    "system": [
+    "certmgr-service.operation": [
         "org.webosports.service.certmgr/listAll",
         "org.webosports.service.certmgr/install",
         "org.webosports.service.certmgr/remove"

--- a/files/sysbus/org.webosports.service.certmgr.perm.json
+++ b/files/sysbus/org.webosports.service.certmgr.perm.json
@@ -1,10 +1,6 @@
 {
     "org.webosports.service.certmgr": [ 
-        "applications",
-        "applications.internal",
-        "services",
-        "settings",
-        "system"
+        "certmgr-service.operation"
     ]
 }
 

--- a/files/sysbus/org.webosports.service.certmgr.role.json.in
+++ b/files/sysbus/org.webosports.service.certmgr.role.json.in
@@ -1,5 +1,6 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/certmgrd",
+    "trustLevel": "oem",
     "type": "privileged",
     "allowedNames": ["org.webosports.service.certmgr"],
     "permissions": [


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
